### PR TITLE
Fix base frame skid steer plugin

### DIFF
--- a/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
+++ b/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
@@ -248,7 +248,7 @@
     <odometryFrame>odom</odometryFrame>
     <torque>1</torque>
     <topicName>cmd_vel</topicName>
-    <broadcastTF>0</broadcastTF>
+    <broadcastTF>1</broadcastTF>
   </plugin>
 </gazebo>
 

--- a/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
+++ b/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
@@ -242,7 +242,7 @@
     <rightRearJoint>base_to_wheel4</rightRearJoint>
     <wheelSeparation>4</wheelSeparation>
     <wheelDiameter>0.1</wheelDiameter>
-    <robotBaseFrame>base_link</robotBaseFrame>
+    <robotBaseFrame>base_footprint</robotBaseFrame>
     <torque>1</torque>
     <topicName>cmd_vel</topicName>
     <broadcastTF>0</broadcastTF>

--- a/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
+++ b/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
@@ -242,7 +242,10 @@
     <rightRearJoint>base_to_wheel4</rightRearJoint>
     <wheelSeparation>4</wheelSeparation>
     <wheelDiameter>0.1</wheelDiameter>
+    <commandTopic>cmd_vel</commandTopic>
+    <odometryTopic>odom</odometryTopic>
     <robotBaseFrame>base_footprint</robotBaseFrame>
+    <odometryFrame>odom</odometryFrame>
     <torque>1</torque>
     <topicName>cmd_vel</topicName>
     <broadcastTF>0</broadcastTF>

--- a/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
+++ b/chapter7_tutorials/robot1_description/urdf/robot1_base_04.xacro
@@ -235,7 +235,7 @@
 <gazebo>
   <plugin name="skid_steer_drive_controller" filename="libgazebo_ros_skid_steer_drive.so">
     <updateRate>100.0</updateRate>
-    <robotNamespace>/</robotNamespace>
+    <robotNamespace></robotNamespace>
     <leftFrontJoint>base_to_wheel1</leftFrontJoint>
     <rightFrontJoint>base_to_wheel3</rightFrontJoint>
     <leftRearJoint>base_to_wheel2</leftRearJoint>


### PR DESCRIPTION
The base frame must be `base_footprint` instead of `base_link`.

@AaronMR @LuisSC  This is potentially broken also in `hydro-devel`.

Merge after #3 
